### PR TITLE
Omeka S 4.x compatibility

### DIFF
--- a/config/module.ini
+++ b/config/module.ini
@@ -6,4 +6,4 @@ module_link              = "https://github.com/hafizchin/DomainManager"
 author_link              = "https://github.com/hafizchin/"
 configurable             = true
 version                  = "2.0.0"
-omeka_version_constraint = "^3.0.0"
+omeka_version_constraint = "^3.0.0 || ^4.0.0"


### PR DESCRIPTION
Simple update to allow using this module in Omeka S 4.x.

Limited testing so far is successful on PHP 7.4 and 8.0.